### PR TITLE
Optimade v0.45, present markdown table and return all info retrieved

### DIFF
--- a/agents/matmaster_agent/optimade_database_agent/constant.py
+++ b/agents/matmaster_agent/optimade_database_agent/constant.py
@@ -3,6 +3,7 @@ OPTIMADE_DATABASE_AGENT_NAME = "optimade_agent"
 from agents.matmaster_agent.constant import CURRENT_ENV
 
 if CURRENT_ENV in ["test", "uat"]:
-    OPTIMADE_URL="http://bekc1366122.bohrium.tech:50001/sse"
+    # OPTIMADE_URL="http://bekc1366122.bohrium.tech:50001/sse"
+    OPTIMADE_URL="http://jjxr1366132.bohrium.tech:50001/sse"
 else:
     OPTIMADE_URL = "https://material-data-retriever-uuid1754467958.app-space.dplink.cc/sse?token=16a1dd29dbb54cf9bf75748ba8df282d"

--- a/agents/matmaster_agent/optimade_database_agent/prompt.py
+++ b/agents/matmaster_agent/optimade_database_agent/prompt.py
@@ -56,8 +56,6 @@ You can call **three MCP tools**:
 
 ## HOW TO CHOOSE A TOOL
 - If the user wants to filter by **elements / formula / logic only** → you MUST use `fetch_structures_with_filter`
-  - ⚠️ If the user provides a **concrete chemical formula** (e.g., "MgO", "TiO2", "Al2O3"), you MUST use `fetch_structures_with_filter`.  
-    ❌ You MUST NOT use `fetch_structures_with_spg` in this case, unless the user **explicitly** mentions a mineral name, structure type, or space group.  
 - If the user wants to filter by a **specific space group number (1–230)** or a **mineral/structure type** (e.g., rutile, spinel, perovskite) → you MUST use `fetch_structures_with_spg` (you can still combine with a base_filter).
 - If the user wants to filter by a **band-gap range** → you MUST use `fetch_structures_with_bandgap` with base_filter and min/max.
 
@@ -84,12 +82,12 @@ To retrieve such materials:
 - Use `fetch_structures_with_filter` when structure is inferred from formula or composition pattern.
 - ✅ Always **explain to the user** whether you are retrieving a specific mineral compound or a broader structure-type family.
 ### Examples:
-- 用户：找一些方镁石 → Tool: `fetch_structures_with_spg`, `chemical_formula_reduced="MgO"`, `spg_number=225`  
-- 用户：查找金红石 → Tool: `fetch_structures_with_spg`, `chemical_formula_reduced="O2Ti"`, `spg_number=136`  
-- 用户：找一些钙钛矿结构的材料 → Tool: `fetch_structures_with_filter`, `chemical_formula_anonymous="ABC3"`  
-- 用户：找一个钙钛矿 → Tool: `fetch_structures_with_spg`, `chemical_formula_reduced="CaO3Ti"`, `spg_number=221`, `n_results=1`  
-- 用户：找一些尖晶石结构的材料 → Tool: `fetch_structures_with_filter`, `chemical_formula_anonymous="AB2C4" AND elements HAS ANY "O"`  
-- 用户：检索尖晶石 → Tool: `fetch_structures_with_spg`, `chemical_formula_reduced="Al2MgO4"`, `spg_number=227`  
+- 用户：找一些方镁石 → Tool: `fetch_structures_with_spg`, `chemical_formula_reduced="MgO"`, `spg_number=225` （此处用 spg 因为“方镁石”是矿物名；如果用户只写“MgO”，则必须用 `fetch_structures_with_filter`）  
+- 用户：查找金红石 → Tool: `fetch_structures_with_spg`, `chemical_formula_reduced="O2Ti"`, `spg_number=136` （此处用 spg 因为“金红石”是矿物名；如果用户只写“TiO2”，则必须用 `fetch_structures_with_filter`）  
+- 用户：找一些钙钛矿结构的材料 → Tool: `fetch_structures_with_filter`, `chemical_formula_anonymous="ABC3"`
+- 用户：找一个钙钛矿 → Tool: `fetch_structures_with_spg`, `chemical_formula_reduced="CaO3Ti"`, `spg_number=221`, `n_results=1` （此处用 spg 因为“钙钛矿”是矿物名；如果用户只写“CaTiO3”，则必须用 `fetch_structures_with_filter`）  
+- 用户：找一些尖晶石结构的材料 → Tool: `fetch_structures_with_filter`, `chemical_formula_anonymous="AB2C4" AND elements HAS ANY "O"`
+- 用户：检索尖晶石 → Tool: `fetch_structures_with_spg`, `chemical_formula_reduced="Al2MgO4"`, `spg_number=227` （此处用 spg 因为“尖晶石”是矿物名；如果用户只写“Al2MgO4”，则必须用 `fetch_structures_with_filter`）  
 
 ## DEFAULT PROVIDERS
 - Raw filter: alexandria, cmr, cod, mcloud, mcloudarchive, mp, mpdd, mpds, nmd, odbx, omdb, oqmd, tcod, twodmatpedia
@@ -102,14 +100,14 @@ The response must always have three parts in order:
 2) A 📈 Markdown table listing all retrieved results.  
 3) A 📦 download link for an archive (.tgz).  
 The table must contain **all retrieved materials** in one complete Markdown table, without omissions, truncation, summaries, or ellipses. The number of rows must exactly equal `n_found`, and even if there are many results (up to 100), they must all be shown in the same table. The 📦 archive link is supplementary and can never replace the full table.  
-表格中必须包含**所有检索到的材料**，必须完整列在一个 Markdown 表格中，绝对不能省略、缩写、总结或用“...”代替。表格的行数必须与 `n_found` 完全一致，即使结果数量很多（最多 100 条），也必须全部列出。📦 压缩包链接只能作为补充，绝不能替代表格。  
+表格中必须包含**所有检索到的材料**，必须完整列在一个 Markdown 表格中，绝对不能省略、缩写、总结或用“...”只展示部分，你必须展示全部检索到的材料在表格中！表格的行数必须与 `n_found` 完全一致，即使结果数量很多（最多 100 条），也必须全部列出。📦 压缩包链接只能作为补充，绝不能替代表格。  
 Each table must always include the following six columns in this fixed order:  
 (1) Formula (`attributes.chemical_formula_reduced`)  
-(2) Elements (list of elements)  
-(3) Space group (`Symbol(Number)`; if only one form is given, map to the other; if none is available, write exactly **Not Provided**)  
+(2) Elements (list of elements; infer from the chemical formula)
+(3) Space group (`Symbol(Number)`; Keys may differ by provider (e.g., `_alexandria_space_group`, `_oqmd_spacegroup`), so you must reason it out yourself; if only one is provided, you must automatically supply the other using your knowledge; if neither is available, write exactly **Not Provided**).
 (4) Download link (CIF or JSON file)  
 (5) Provider (inferred from provider URL)  
-(6) ID (`cleaned_structures[i]["id"]`, shortened)  
+(6) ID (`cleaned_structures[i]["id"]`)  
 If any property is missing, it must be filled with exactly **Not Provided** (no slashes, alternatives, or translations). Extra columns (e.g., lattice vectors, band gap, formation energy) may only be added if explicitly requested; if such data is unavailable, also fill with **Not Provided**.  
 If no results are found (`n_found = 0`), clearly state that no matching structures were retrieved, repeat the applied filters, and suggest loosening the criteria, but do not generate an empty table. Always verify that the number of table rows equals `n_found`; if they do not match, regenerate the table until correct. Never claim token or brevity issues, as results are already capped at 100 maximum.
 

--- a/agents/matmaster_agent/prompt.py
+++ b/agents/matmaster_agent/prompt.py
@@ -364,13 +364,25 @@ MANDATORY NOTIFICATIONS:
     - Capabilities:
       - Perform advanced queries on elements, number of elements, chemical formulas (reduced, descriptive, anonymous), and logical combinations using AND, OR, NOT with parentheses
       - Support provider-specific mappings for space group (1–230) and band-gap range queries
-      - Retrieve results in .cif (for visualization/simulation) or .json (for full metadata) from multiple OPTIMADE-compliant databases (e.g., Alexandria, CMR, OQMD, MP, etc.), and present them in a structured table (default columns: ID, Provider, Formula, Elements, Space group, Download link). Supports quantity-aware queries via n_results
+      - Retrieve results in .cif (for visualization/simulation) or .json (for full metadata) from multiple OPTIMADE-compliant databases (e.g., Alexandria, CMR, OQMD, MP, etc.), and present **all retrieved entries** in a single complete Markdown table (default columns: ID, Provider, Formula, Elements, Space group, Download link). Supports quantity-aware queries via `n_results`
     - Example Queries:
       - "找3个含油 Si O，且含有四种元素的，不能同时含有铁铝的材料，从 alexandria, cmr, nmd, oqmd, omdb 中查找。"
       - "找到一些 A2B3C4 的材料，不能含 Fe, F, Cl, H 元素，要含有铝或者镁或者钠，我要全部信息。"
       - "找一些 ZrO，从 mpds, cmr, alexandria, omdb, odbx 里面找。"
       - "查找一个 gamma 相的 TiAl 合金。"
       - "找一些含铝的，能带在 1.0–2.0 的材料。"
+
+   ## ⚠️ Mandatory Table Display Rule:
+      ** The Markdown table must always be displayed exactly as returned by the `optimade_agent`, with **all entries included in full**. No omission, truncation, summarization, filtering, or ellipses are allowed.  
+      ** 你必须展示完整的optimade agent返回的表格！禁止只展示部分optimade_agent返回的表格或遗漏表格及任何信息！
+
+   ## RESPONSE FORMAT
+   The response must always have three parts in order:  
+   1) A brief explanation of the applied filters and providers.  
+   2) A 📈 Markdown table listing all retrieved results.  
+   3) A 📦 download link for an archive (.tgz).  
+   The table must contain **all retrieved materials** in one complete Markdown table, without omissions, truncation, summaries, or ellipses. The number of rows must exactly equal `n_found`, and even if there are many results (up to 100), they must all be shown in the same table. The 📦 archive link is supplementary and can never replace the full table.  
+   表格中必须包含**所有检索到的材料**，必须完整列在一个 Markdown 表格中，绝对不能省略、缩写、总结或用“...”只展示部分，你必须展示全部检索到的材料在表格中！即使结果数量很多（最多 100 条），也必须全部列出。📦 压缩包链接只能作为补充，绝不能替代表格。  
 
 11. **{ORGANIC_REACTION_AGENT_NAME}** - **Organic reaction specialist**
     - Purpose: Find transition states and calculate reaction profiles

--- a/agents/matmaster_agent/prompt.py
+++ b/agents/matmaster_agent/prompt.py
@@ -364,12 +364,12 @@ MANDATORY NOTIFICATIONS:
     - Capabilities:
       - Perform advanced queries on elements, number of elements, chemical formulas (reduced, descriptive, anonymous), and logical combinations using AND, OR, NOT with parentheses
       - Support provider-specific mappings for space group (1–230) and band-gap range queries
-      - Retrieve results in `.cif` (for visualization/simulation) or `.json` (for full metadata) from multiple OPTIMADE-compliant databases (e.g., Alexandria, CMR, OQMD, MP, etc.), with support for quantity-aware queries (e.g., “find one”, “three results”) via `n_results`
+      - Retrieve results in .cif (for visualization/simulation) or .json (for full metadata) from multiple OPTIMADE-compliant databases (e.g., Alexandria, CMR, OQMD, MP, etc.), and present them in a structured table (default columns: ID, Provider, Formula, Elements, Space group, Download link). Supports quantity-aware queries via n_results
     - Example Queries:
       - "找3个含油 Si O，且含有四种元素的，不能同时含有铁铝的材料，从 alexandria, cmr, nmd, oqmd, omdb 中查找。"
       - "找到一些 A2B3C4 的材料，不能含 Fe, F, Cl, H 元素，要含有铝或者镁或者钠，我要全部信息。"
       - "找一些 ZrO，从 mpds, cmr, alexandria, omdb, odbx 里面找。"
-      - "查找 gamma 相的 TiAl 合金。"
+      - "查找一个 gamma 相的 TiAl 合金。"
       - "找一些含铝的，能带在 1.0–2.0 的材料。"
 
 11. **{ORGANIC_REACTION_AGENT_NAME}** - **Organic reaction specialist**


### PR DESCRIPTION
有低概率在表格中只显示部分检索结果，不显示全，不过也不太影响用户观感
<img width="3420" height="1894" alt="image" src="https://github.com/user-attachments/assets/d881980e-5668-4e82-9803-9b4419cfd999" />
<img width="3420" height="1894" alt="image" src="https://github.com/user-attachments/assets/a92e9e90-b90d-460e-a219-0d4b9253cd74" />
<img width="3420" height="1894" alt="image" src="https://github.com/user-attachments/assets/b4a81e7e-3830-4932-9e1c-6178af96f16e" />
<img width="3420" height="1894" alt="image" src="https://github.com/user-attachments/assets/ffebad2c-20c2-43d4-af94-39e944a9f0f5" />
<img width="3420" height="1894" alt="image" src="https://github.com/user-attachments/assets/8d3b3ea3-5eb9-4fae-8342-0bc0d5aef2a3" />
<img width="3420" height="1894" alt="image" src="https://github.com/user-attachments/assets/609ac566-1eee-4550-8422-e16e6efc1d17" />
<img width="3420" height="1894" alt="image" src="https://github.com/user-attachments/assets/292faed4-b8ca-4535-bba7-70ad8d39e9d6" />
