### PR TITLE
fix: Update image and machine type used by ABACUS_agent

### DIFF
--- a/agents/matmaster_agent/ABACUS_agent/constant.py
+++ b/agents/matmaster_agent/ABACUS_agent/constant.py
@@ -15,10 +15,10 @@ ABACUS_AGENT_NAME = 'ABACUS_calculation_agent'
 ABACUS_CALCULATOR_BOHRIUM_EXECUTOR = copy.deepcopy(BohriumExecutor)
 ABACUS_CALCULATOR_BOHRIUM_EXECUTOR['machine']['remote_profile'][
     'image_address'
-] = 'registry.dp.tech/dptech/dp/native/prod-22618/abacusagenttools:v0.2-openmp'
+] = 'registry.dp.tech/dptech/dp/native/prod-22618/abacusagenttoolsv:0.2.0-9f6921f-c32m128'
 ABACUS_CALCULATOR_BOHRIUM_EXECUTOR['machine']['remote_profile'][
     'machine_type'
-] = 'c16_m32_cpu'
+] = 'c32_m128_cpu'
 ABACUS_CALCULATOR_BOHRIUM_STORAGE = copy.deepcopy(BohriumStorge)
 
 EXECUTOR_MAP = {


### PR DESCRIPTION
fix:Provide new image for ABACUS_agent with fixed command to run ABACUS on c32_m128_cpu.