### PR TITLE
feat: split visualize_data tools into cases with / without input data files

### DIFF
--- a/agents/matmaster_agent/flow_agents/scene_agent/model.py
+++ b/agents/matmaster_agent/flow_agents/scene_agent/model.py
@@ -69,7 +69,7 @@ class SceneEnum(DescriptiveEnum):
 
     # postprocess
     VISUALIZE_DATA = (
-        'visualize_data',
+        'data_visualization',
         'Involves visualization or charting requirements',
     )
     POST_MD_ANALYSIS = (

--- a/agents/matmaster_agent/sub_agents/tools.py
+++ b/agents/matmaster_agent/sub_agents/tools.py
@@ -1152,7 +1152,7 @@ ALL_TOOLS = {
             'Cost / Notes: Medium.'
         ),
     },
-    'visualize_data': {
+    'visualize_data_from_file': {
         'belonging_agent': VisualizerAgentName,
         'scene': [SceneEnum.VISUALIZE_DATA, SceneEnum.UNIVERSAL],
         'description': (
@@ -1161,6 +1161,18 @@ ALL_TOOLS = {
             'Prerequisites / Inputs: Data file URL.\n'
             'Outputs: Plots.\n'
             'Cannot do / Limits: Data files only.\n'
+            'Cost / Notes: Low.'
+        ),
+        'bypass_confirmation': True,
+    },
+    'visualize_data_from_prompt': {
+        'belonging_agent': VisualizerAgentName,
+        'scene': [SceneEnum.VISUALIZE_DATA, SceneEnum.UNIVERSAL],
+        'description': (
+            'What it does: Create plots from prompts.\n'
+            'When to use: Quick visualize data embedded in prompt.\n'
+            'Outputs: Plots.\n'
+            'Cannot do / Limits: Plot requests with valid data only.\n'
             'Cost / Notes: Low.'
         ),
         'bypass_confirmation': True,


### PR DESCRIPTION
<img width="1840" height="1637" alt="fe02f3b3-7082-470c-9a8d-c6bf5c0a5e4a" src="https://github.com/user-attachments/assets/6f588c17-d36a-42c2-b614-3ac43b291f6a" />
<img width="1840" height="2791" alt="beac8f88-a039-4791-951f-ad90f63628fb" src="https://github.com/user-attachments/assets/53610b2c-3a6d-4ca8-8607-2959bce53694" />
